### PR TITLE
Free buffers memery in case creating new req fails

### DIFF
--- a/esp_request.c
+++ b/esp_request.c
@@ -29,10 +29,10 @@ static int resolve_dns(const char *host, struct sockaddr_in *ip) {
     struct hostent *he;
     struct in_addr **addr_list;
     he = gethostbyname(host);
-    if(he == NULL)
+    if (he == NULL)
         return -1;
     addr_list = (struct in_addr **)he->h_addr_list;
-    if(addr_list[0] == NULL)
+    if (addr_list[0] == NULL)
         return -1;
     ip->sin_family = AF_INET;
     memcpy(&ip->sin_addr, addr_list[0], sizeof(ip->sin_addr));
@@ -47,7 +47,7 @@ static char *http_auth_basic_encode(const char *username, const char *password)
 
 static int nossl_connect(request_t *req)
 {
-    int socket;
+    int theSocket;
     struct sockaddr_in remote_ip;
     struct timeval tv;
     req_list_t *host, *port, *timeout;
@@ -56,17 +56,17 @@ static int nossl_connect(request_t *req)
     host = req_list_get_key(req->opt, "host");
     REQ_CHECK(host == NULL, "host = NULL", return -1);
 
-    if(inet_pton(AF_INET, (const char*)host->value, &remote_ip.sin_addr) != 1) {
-        if(resolve_dns((const char*)host->value, &remote_ip) < 0) {
+    if (inet_pton(AF_INET, (const char*)host->value, &remote_ip.sin_addr) != 1) {
+        if (resolve_dns((const char*)host->value, &remote_ip) < 0) {
             return -1;
         }
     }
 
-    socket = socket(PF_INET, SOCK_STREAM, 0);
-    REQ_CHECK(socket < 0, "socket failed", return -1);
+    theSocket = socket(PF_INET, SOCK_STREAM, 0);
+    REQ_CHECK(theSocket < 0, "socket failed", return -1);
 
     port = req_list_get_key(req->opt, "port");
-    if(port == NULL)
+    if (port == NULL)
         return -1;
 
     remote_ip.sin_family = AF_INET;
@@ -74,21 +74,21 @@ static int nossl_connect(request_t *req)
 
     tv.tv_sec = 10; //default timeout is 10 seconds
     timeout = req_list_get_key(req->opt, "timeout");
-    if(timeout) {
+    if (timeout) {
         tv.tv_sec = atoi(timeout->value);
     }
     tv.tv_usec = 0;
-    setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(theSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
     ESP_LOGD(REQ_TAG, "[sock=%d],connecting to server IP:%s,Port:%s...",
-             socket, ipaddr_ntoa((const ip_addr_t*)&remote_ip.sin_addr.s_addr), (char*)port->value);
-    if(connect(socket, (struct sockaddr *)(&remote_ip), sizeof(struct sockaddr)) != 0) {
-        close(socket);
+        theSocket, ipaddr_ntoa((const ip_addr_t*)&remote_ip.sin_addr.s_addr), (char*)port->value);
+    if (connect(theSocket, (struct sockaddr *)(&remote_ip), sizeof(struct sockaddr)) != 0) {
+        close(theSocket);
         req->socket = -1;
         return -1;
     }
-    req->socket = socket;
-    return socket;
+    req->socket = theSocket;
+    return theSocket;
 }
 static int ssl_connect(request_t *req)
 {
@@ -110,11 +110,12 @@ static char *ws_esc(char *buffer, int len, int *outlen)
     data_buffer[header_len++] = WS_OPCODE_BINARY | WS_FIN;
 
     // NOTE: no support for > 16-bit sized messages
-    if(len > 125) {
+    if (len > 125) {
         data_buffer[header_len++] = WS_SIZE16 | WS_MASK;
         data_buffer[header_len++] = (uint8_t)(len >> 8);
         data_buffer[header_len++] = (uint8_t)(len & 0xFF);
-    } else {
+    }
+    else {
         data_buffer[header_len++] = (uint8_t)(len | WS_MASK);
     }
     mask = &data_buffer[header_len];
@@ -123,7 +124,7 @@ static char *ws_esc(char *buffer, int len, int *outlen)
     data_buffer[header_len++] = rand() & 0xFF;
     data_buffer[header_len++] = rand() & 0xFF;
 
-    for(int i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         data_buffer[header_len++] = (buffer[i] ^ mask[i % 4]);
     }
     *outlen = header_len;
@@ -133,39 +134,42 @@ static int ws_unesc(unsigned char *ws_buffer, unsigned char *buffer, int len)
 {
     int payloadLen;
     unsigned char *data_ptr = ws_buffer, opcode, mask, *maskKey = NULL;
-    if(len <= 0)
+    if (len <= 0)
     {
         return -1;
     }
     opcode = (*data_ptr & 0x0F);
-    data_ptr ++;
+    data_ptr++;
     mask = ((*data_ptr >> 7) & 0x01);
     payloadLen = (*data_ptr & 0x7F);
     data_ptr++;
     ESP_LOGI(REQ_TAG, "Opcode: %d, mask: %d, len: %d\r\n", opcode, mask, payloadLen);
-    if(payloadLen == 126) {
+    if (payloadLen == 126) {
         // headerLen += 2;
         payloadLen = data_ptr[0] << 8 | data_ptr[1];
         data_ptr += 2;
-    } else if(payloadLen == 127) {
+    }
+    else if (payloadLen == 127) {
         // headerLen += 8;
 
-        if(data_ptr[0] != 0 || data_ptr[1] != 0 || data_ptr[2] != 0 || data_ptr[3] != 0) {
+        if (data_ptr[0] != 0 || data_ptr[1] != 0 || data_ptr[2] != 0 || data_ptr[3] != 0) {
             // really too big!
             payloadLen = 0xFFFFFFFF;
-        } else {
+        }
+        else {
             payloadLen = data_ptr[4] << 24 | data_ptr[5] << 16 | data_ptr[6] << 8 | data_ptr[7];
         }
         data_ptr += 8;
     }
 
-    if(mask) {
+    if (mask) {
         maskKey = data_ptr;
         data_ptr += 4;
-        for(int i = 0; i < payloadLen; i++) {
+        for (int i = 0; i < payloadLen; i++) {
             buffer[i] = (data_ptr[i] ^ maskKey[i % 4]);
         }
-    } else {
+    }
+    else {
         memcpy(buffer, data_ptr, payloadLen);
     }
     return payloadLen;
@@ -173,7 +177,7 @@ static int ws_unesc(unsigned char *ws_buffer, unsigned char *buffer, int len)
 
 static int ssl_write(request_t *req, char *buffer, int len)
 {
-    if(req->valid_websocket) {
+    if (req->valid_websocket) {
         int ws_len = 0;
         char *ws_buffer = ws_esc(buffer, len, &ws_len);
         SSL_write(req->ssl, ws_buffer, ws_len);
@@ -185,7 +189,7 @@ static int ssl_write(request_t *req, char *buffer, int len)
 
 static int nossl_write(request_t *req, char *buffer, int len)
 {
-    if(req->valid_websocket) {
+    if (req->valid_websocket) {
         int ws_len = 0;
         char *ws_buffer = ws_esc(buffer, len, &ws_len);
         write(req->socket, ws_buffer, ws_len);
@@ -198,12 +202,13 @@ static int nossl_write(request_t *req, char *buffer, int len)
 static int ssl_read(request_t *req, char *buffer, int len)
 {
     int ret = -1;
-    if(req->valid_websocket) {
-        unsigned char *ws_buffer = (unsigned char*) malloc(len + MAX_WEBSOCKET_HEADER_SIZE);
+    if (req->valid_websocket) {
+        unsigned char *ws_buffer = (unsigned char*)malloc(len + MAX_WEBSOCKET_HEADER_SIZE);
         ret = SSL_read(req->ssl, ws_buffer, len + MAX_WEBSOCKET_HEADER_SIZE);
         ret = ws_unesc(ws_buffer, (unsigned char *)buffer, ret);
         free(ws_buffer);
-    } else {
+    }
+    else {
         ret = SSL_read(req->ssl, buffer, len);
     }
 
@@ -213,12 +218,13 @@ static int ssl_read(request_t *req, char *buffer, int len)
 static int nossl_read(request_t *req, char *buffer, int len)
 {
     int ret = -1;
-    if(req->valid_websocket) {
-        unsigned char *ws_buffer = (unsigned char*) malloc(len + MAX_WEBSOCKET_HEADER_SIZE);
+    if (req->valid_websocket) {
+        unsigned char *ws_buffer = (unsigned char*)malloc(len + MAX_WEBSOCKET_HEADER_SIZE);
         ret = read(req->socket, ws_buffer, len + MAX_WEBSOCKET_HEADER_SIZE);
         ret = ws_unesc(ws_buffer, (unsigned char *)buffer, ret);
         free(ws_buffer);
-    } else {
+    }
+    else {
         ret = read(req->socket, buffer, len);
     }
     return ret;
@@ -246,43 +252,47 @@ static int req_setopt_from_uri(request_t *req, const char* uri)
 
     req->is_websocket = 0;
 
-    if(strcasecmp(puri->scheme, "https") == 0) {
+    if (strcasecmp(puri->scheme, "https") == 0) {
         req_setopt(req, REQ_SET_SECURITY, "true");
-    } else if(strcasecmp(puri->scheme, "ws") == 0) {
+    }
+    else if (strcasecmp(puri->scheme, "ws") == 0) {
         req_setopt(req, REQ_SET_SECURITY, "false");
         req->is_websocket = 1;
         strcpy(port, "80");
         port[2] = 0;
-    } else if(strcasecmp(puri->scheme, "wss") == 0) {
+    }
+    else if (strcasecmp(puri->scheme, "wss") == 0) {
         req_setopt(req, REQ_SET_SECURITY, "true");
         req->is_websocket = 1;
-    } else {
+    }
+    else {
         req_setopt(req, REQ_SET_SECURITY, "false");
         strcpy(port, "80");
         port[2] = 0;
     }
 
-    if(puri->username && puri->password) {
+    if (puri->username && puri->password) {
         char *auth = http_auth_basic_encode(puri->username, puri->password);
-        if(auth) {
+        if (auth) {
             req_setopt(req, REQ_SET_HEADER, auth);
             free(auth);
         }
 
     }
-    if(puri->username) {
+    if (puri->username) {
         req_list_set_key(req->opt, "username", puri->username);
     }
-    if(puri->password) {
+    if (puri->password) {
         req_list_set_key(req->opt, "password", puri->password);
     }
 
     req_setopt(req, REQ_SET_HOST, puri->host);
     req_setopt(req, REQ_SET_PATH, puri->path);
     //port
-    if(puri->port) {
+    if (puri->port) {
         req_setopt(req, REQ_SET_PORT, puri->port);
-    } else {
+    }
+    else {
         req_setopt(req, REQ_SET_PORT, port);
     }
     free_parsed_uri(puri);
@@ -290,31 +300,34 @@ static int req_setopt_from_uri(request_t *req, const char* uri)
 }
 request_t *req_new(const char *uri)
 {
-    unsigned char random_key[16] = { 0 }, b64_key[32] = {0};
+    unsigned char random_key[16] = { 0 }, b64_key[32] = { 0 };
     request_t *req = malloc(sizeof(request_t));
 
     REQ_CHECK(req == NULL, "Error allocate req", return NULL);
     memset(req, 0, sizeof(request_t));
 
     req->buffer = malloc(sizeof(req_buffer_t));
-    REQ_CHECK(req->buffer == NULL, "Error allocate buffer", return NULL);
+    REQ_CHECK(req->buffer == NULL, "Error allocate buffer", free(req); return NULL);
     memset(req->buffer, 0, sizeof(req_buffer_t));
 
     req->buffer->data = malloc(REQ_BUFFER_LEN + 1); //1 byte null for end of string
-    //TODO: Free req before return
-    REQ_CHECK(req->buffer->data == NULL, "Error allocate buffer", return NULL);
+                                                    //TODO: Free req before return
+    REQ_CHECK(req->buffer->data == NULL, "Error allocate buffer", free(req); free(req->buffer);  return NULL);
 
     req->opt = malloc(sizeof(req_list_t));
+    REQ_CHECK(req->opt == NULL, "Error create opt", free(req); free(req->buffer); return NULL);
     memset(req->opt, 0, sizeof(req_list_t));
+
     req->header = malloc(sizeof(req_list_t));
+    REQ_CHECK(req->header == NULL, "Error create header", free(req); free(req->buffer); free(req->opt); return NULL);
     memset(req->header, 0, sizeof(req_list_t));
 
     req->response = malloc(sizeof(response_t));
-    REQ_CHECK(req->response == NULL, "Error create response", return NULL);
+    REQ_CHECK(req->response == NULL, "Error create response", free(req); free(req->buffer); free(req->opt); free(req->header);  return NULL);
     memset(req->response, 0, sizeof(response_t));
 
     req->response->header = malloc(sizeof(req_list_t));
-    REQ_CHECK(req->response->header == NULL, "Error create response header", return NULL);
+    REQ_CHECK(req->response->header == NULL, "Error create response header", free(req); free(req->buffer); free(req->opt); free(req->header); free(req->response); return NULL);
     memset(req->response->header, 0, sizeof(req_list_t));
 
     req_setopt(req, REQ_SET_PROTOCOL, (void*)PROTOCOL_HTTP);
@@ -323,13 +336,13 @@ request_t *req_new(const char *uri)
     req_setopt_from_uri(req, uri);
 
     req->valid_websocket = 0;
-    if(req->is_websocket) {
+    if (req->is_websocket) {
         int i;
-        for(i = 0; i < sizeof(random_key); i++) {
+        for (i = 0; i < sizeof(random_key); i++) {
             random_key[i] = rand() & 0xFF;
         }
         size_t outlen = 0;
-        mbedtls_base64_encode(b64_key, 32,  &outlen, random_key, 16);
+        mbedtls_base64_encode(b64_key, 32, &outlen, random_key, 16);
 
         req_setopt(req, REQ_SET_HEADER, "Connection: Upgrade");
         req_setopt(req, REQ_SET_HEADER, "Upgrade: websocket");
@@ -346,94 +359,98 @@ request_t *req_new(const char *uri)
 void req_setopt(request_t *req, REQ_OPTS opt, void* data)
 {
     int post_len;
-    char len_str[10] = {0};
+    char len_str[10] = { 0 };
     req_list_t *tmp;
     char *host_w_port = malloc(1024);
-    if(!req || !data)
+    if (!req || !data)
         return;
-    switch(opt) {
-        case REQ_SET_METHOD:
-            req_list_set_key(req->opt, "method", data);
-            break;
-        case REQ_SET_HEADER:
-            req_list_set_from_string(req->header, data);
-            break;
-        case REQ_SET_HOST:
-            req_list_set_key(req->opt, "host", data);
-            tmp = req_list_get_key(req->opt, "port");
-            if(tmp != NULL) {
-                sprintf(host_w_port, "%s:%s", (char*)data, (char*)tmp->value);
-            } else {
-                sprintf(host_w_port, "%s", (char*)data);
-            }
+    switch (opt) {
+    case REQ_SET_METHOD:
+        req_list_set_key(req->opt, "method", data);
+        break;
+    case REQ_SET_HEADER:
+        req_list_set_from_string(req->header, data);
+        break;
+    case REQ_SET_HOST:
+        req_list_set_key(req->opt, "host", data);
+        tmp = req_list_get_key(req->opt, "port");
+        if (tmp != NULL) {
+            sprintf(host_w_port, "%s:%s", (char*)data, (char*)tmp->value);
+        }
+        else {
+            sprintf(host_w_port, "%s", (char*)data);
+        }
+        req_list_set_key(req->header, "Host", host_w_port);
+        break;
+    case REQ_SET_PORT:
+        req_list_set_key(req->opt, "port", data);
+        tmp = req_list_get_key(req->opt, "host");
+        if (tmp != NULL) {
+            sprintf(host_w_port, "%s:%s", (char*)tmp->value, (char*)data);
             req_list_set_key(req->header, "Host", host_w_port);
-            break;
-        case REQ_SET_PORT:
-            req_list_set_key(req->opt, "port", data);
-            tmp = req_list_get_key(req->opt, "host");
-            if(tmp != NULL) {
-                sprintf(host_w_port, "%s:%s", (char*)tmp->value, (char*)data);
-                req_list_set_key(req->header, "Host", host_w_port);
-            }
+        }
 
-            break;
-        case REQ_SET_PATH:
-            req_list_set_key(req->opt, "path", data);
-            break;
-        case REQ_SET_URI:
-            req_setopt_from_uri(req, data);
-            break;
-        case REQ_SET_PROTOCOL:
-            req->protocol = (REQ_PROTOCOL)data;
+        break;
+    case REQ_SET_PATH:
+        req_list_set_key(req->opt, "path", data);
+        break;
+    case REQ_SET_URI:
+        req_setopt_from_uri(req, data);
+        break;
+    case REQ_SET_PROTOCOL:
+        req->protocol = (REQ_PROTOCOL)data;
 
-            if(req->protocol == PROTOCOL_HTTP) {
-                req_list_set_key(req->opt, "protocol", "HTTP/1.1");
-            } else if(req->protocol == PROTOCOL_SIP) {
-                req_list_set_key(req->opt, "protocol", "SIP/2.0");
-            } else {
-                req_list_set_key(req->opt, "protocol", "Unknown");
-            }
+        if (req->protocol == PROTOCOL_HTTP) {
+            req_list_set_key(req->opt, "protocol", "HTTP/1.1");
+        }
+        else if (req->protocol == PROTOCOL_SIP) {
+            req_list_set_key(req->opt, "protocol", "SIP/2.0");
+        }
+        else {
+            req_list_set_key(req->opt, "protocol", "Unknown");
+        }
 
-            break;
-        case REQ_SET_SECURITY:
-            req_list_set_key(req->opt, "secure", data);
-            if(req_list_check_key(req->opt, "secure", "true")) {
-                ESP_LOGD(REQ_TAG, "Secure");
-                req->_read = ssl_read;
-                req->_write = ssl_write;
-                req->_connect = ssl_connect;
-                req->_close = ssl_close;
-            } else {
-                req->_read = nossl_read;
-                req->_write = nossl_write;
-                req->_connect = nossl_connect;
-                req->_close = nossl_close;
-            }
+        break;
+    case REQ_SET_SECURITY:
+        req_list_set_key(req->opt, "secure", data);
+        if (req_list_check_key(req->opt, "secure", "true")) {
+            ESP_LOGD(REQ_TAG, "Secure");
+            req->_read = ssl_read;
+            req->_write = ssl_write;
+            req->_connect = ssl_connect;
+            req->_close = ssl_close;
+        }
+        else {
+            req->_read = nossl_read;
+            req->_write = nossl_write;
+            req->_connect = nossl_connect;
+            req->_close = nossl_close;
+        }
 
-            break;
-        case REQ_SET_POSTFIELDS:
-            req_list_set_key(req->header, "Content-Type", "application/x-www-form-urlencoded");
-            req_list_set_key(req->opt, "method", "POST");
-        case REQ_SET_DATAFIELDS:
-            post_len = strlen((char*)data);
-            sprintf(len_str, "%d", post_len);
-            req_list_set_key(req->opt, "postfield", data);
-            req_list_set_key(req->header, "Content-Length", len_str);
-            break;
-        case REQ_FUNC_UPLOAD_CB:
-            req->upload_callback = data;
-            break;
-        case REQ_FUNC_DOWNLOAD_CB:
-            req->download_callback = data;
-            break;
-        case REQ_FUNC_WEBSOCKET:
-            req->websocket_callback = data;
-            break;
-        case REQ_REDIRECT_FOLLOW:
-            req_list_set_key(req->opt, "follow", data);
-            break;
-        default:
-            break;
+        break;
+    case REQ_SET_POSTFIELDS:
+        req_list_set_key(req->header, "Content-Type", "application/x-www-form-urlencoded");
+        req_list_set_key(req->opt, "method", "POST");
+    case REQ_SET_DATAFIELDS:
+        post_len = strlen((char*)data);
+        sprintf(len_str, "%d", post_len);
+        req_list_set_key(req->opt, "postfield", data);
+        req_list_set_key(req->header, "Content-Length", len_str);
+        break;
+    case REQ_FUNC_UPLOAD_CB:
+        req->upload_callback = data;
+        break;
+    case REQ_FUNC_DOWNLOAD_CB:
+        req->download_callback = data;
+        break;
+    case REQ_FUNC_WEBSOCKET:
+        req->websocket_callback = data;
+        break;
+    case REQ_REDIRECT_FOLLOW:
+        req_list_set_key(req->opt, "follow", data);
+        break;
+    default:
+        break;
     }
     free(host_w_port);
 }
@@ -457,7 +474,7 @@ static int req_process_upload(request_t *req)
 
     //TODO: Check header len < REQ_BUFFER_LEN
     found = req->header;
-    while(found->next != NULL) {
+    while (found->next != NULL) {
         found = found->next;
         tx_write_len += sprintf(req->buffer->data + tx_write_len, "%s: %s\r\n", (char*)found->key, (char*)found->value);
     }
@@ -468,18 +485,18 @@ static int req_process_upload(request_t *req)
     REQ_CHECK(req->_write(req, req->buffer->data, tx_write_len) < 0, "Error write header", return -1);
 
     found = req_list_get_key(req->opt, "postfield");
-    if(found) {
+    if (found) {
         ESP_LOGD(REQ_TAG, "Begin write %d bytes", strlen((char*)found->value));
         int bwrite = req->_write(req, (char*)found->value, strlen((char*)found->value));
         ESP_LOGD(REQ_TAG, "end write %d bytes", bwrite);
-        if(bwrite < 0) {
+        if (bwrite < 0) {
             ESP_LOGE(REQ_TAG, "Error write");
             return -1;
         }
     }
 
-    if(req->upload_callback) {
-        while((tx_write_len = req->upload_callback(req, (void *)req->buffer->data, REQ_BUFFER_LEN)) > 0) {
+    if (req->upload_callback) {
+        while ((tx_write_len = req->upload_callback(req, (void *)req->buffer->data, REQ_BUFFER_LEN)) > 0) {
             REQ_CHECK(req->_write(req, req->buffer->data, tx_write_len) < 0, "Error write data", return -1);
         }
     }
@@ -500,20 +517,20 @@ static int fill_buffer(request_t *req)
     int bread;
     int bytes_inside_buffer = req->buffer->bytes_write - req->buffer->bytes_read;
     int buffer_free_bytes;
-    if(bytes_inside_buffer)
+    if (bytes_inside_buffer)
     {
         memmove((void*)req->buffer->data, (void*)(req->buffer->data + req->buffer->bytes_read),
-                bytes_inside_buffer);
+            bytes_inside_buffer);
         req->buffer->bytes_read = 0;
         req->buffer->bytes_write = bytes_inside_buffer;
-        if(req->buffer->bytes_write < 0)
+        if (req->buffer->bytes_write < 0)
             req->buffer->bytes_write = 0;
         ESP_LOGD(REQ_TAG, "move=%d, write=%d, read=%d", bytes_inside_buffer, req->buffer->bytes_write, req->buffer->bytes_read);
     }
-    if(!req->buffer->at_eof)
+    if (!req->buffer->at_eof)
     {
         //reset if buffer full
-        if(req->buffer->bytes_write == req->buffer->bytes_read) {
+        if (req->buffer->bytes_write == req->buffer->bytes_read) {
             req->buffer->bytes_write = 0;
             req->buffer->bytes_read = 0;
         }
@@ -522,14 +539,14 @@ static int fill_buffer(request_t *req)
         bread = req->_read(req, (void*)(req->buffer->data + req->buffer->bytes_write), buffer_free_bytes);
         // ESP_LOGD(REQ_TAG, "bread = %d, bytes_write = %d, buffer_free_bytes = %d", bread, req->buffer->bytes_write, buffer_free_bytes);
         ESP_LOGD(REQ_TAG, "End read, byte read= %d bytes", bread);
-        if(bread < 0) {
+        if (bread < 0) {
             req->buffer->at_eof = 1;
             return -1;
         }
         req->buffer->bytes_write += bread;
         req->buffer->data[req->buffer->bytes_write] = 0;//terminal string
 
-        if(bread == 0) {
+        if (bread == 0) {
             req->buffer->at_eof = 1;
         }
     }
@@ -541,11 +558,11 @@ static int fill_buffer(request_t *req)
 static char *req_readline(request_t *req)
 {
     char *cr, *ret = NULL;
-    if(req->buffer->bytes_read + 2 > req->buffer->bytes_write) {
+    if (req->buffer->bytes_read + 2 > req->buffer->bytes_write) {
         return NULL;
     }
     cr = strstr(req->buffer->data + req->buffer->bytes_read, "\r\n");
-    if(cr == NULL) {
+    if (cr == NULL) {
         return NULL;
     }
     memset(cr, 0, 2);
@@ -565,50 +582,53 @@ static int req_process_download(request_t *req)
     req->response->len = 0;
     do {
         fill_buffer(req);
-        if(process_header) {
-            while((line = req_readline(req)) != NULL) {
-                if(line[0] == 0) {
+        if (process_header) {
+            while ((line = req_readline(req)) != NULL) {
+                if (line[0] == 0) {
                     ESP_LOGD(REQ_TAG, "end process_idx=%d", req->buffer->bytes_read);
                     header_off = req->buffer->bytes_read;
                     process_header = 0; //end of http header
                     req_list_t *server_key = req_list_get_key(req->response->header, "Sec-WebSocket-Accept");
                     req_list_t *client_key = req_list_get_key(req->header, "Sec-WebSocket-Key");
-                    if(server_key && client_key) {
-                        unsigned char client_key_b64[64], valid_client_key[20], accept_key[32] = {0};
+                    if (server_key && client_key) {
+                        unsigned char client_key_b64[64], valid_client_key[20], accept_key[32] = { 0 };
                         int key_len = sprintf((char*)client_key_b64, "%s258EAFA5-E914-47DA-95CA-C5AB0DC85B11", (char*)client_key->value);
                         mbedtls_sha1(client_key_b64, (size_t)key_len, valid_client_key);
                         size_t outlen = 0;
-                        mbedtls_base64_encode(accept_key, 32,  &outlen, valid_client_key, 20);
+                        mbedtls_base64_encode(accept_key, 32, &outlen, valid_client_key, 20);
                         accept_key[outlen] = 0;
 
-                        if(strcmp((char*)accept_key, (char*)server_key->value) == 0) {
+                        if (strcmp((char*)accept_key, (char*)server_key->value) == 0) {
                             req->valid_websocket = 1;
 
-                            if(req->websocket_callback) {
+                            if (req->websocket_callback) {
                                 req->websocket_callback(req, WS_CONNECTED, NULL, 0);
                             }
                         }
                         ESP_LOGD(REQ_TAG, "server key=%s, send_key=%s, accept_key=%s, valid=%d", (char *)server_key->value, (char*)client_key->value, accept_key, req->valid_websocket);
                     }
                     break;
-                } else {
-                    if(req->response->status_code < 0) {
+                }
+                else {
+                    if (req->response->status_code < 0) {
                         char *temp = NULL;
                         int status_idx = 0;
-                        if(req->protocol == PROTOCOL_HTTP) {
+                        if (req->protocol == PROTOCOL_HTTP) {
                             temp = strstr(line, "HTTP/1.");
                             status_idx = 9;
-                        } else if(req->protocol == PROTOCOL_SIP) {
+                        }
+                        else if (req->protocol == PROTOCOL_SIP) {
                             temp = strstr(line, "SIP/2.0");
                             status_idx = 8;
                         }
-                        if(temp) {
+                        if (temp) {
                             char statusCode[4] = { 0 };
                             memcpy(statusCode, temp + status_idx, 3);
                             req->response->status_code = atoi(statusCode);
                             ESP_LOGD(REQ_TAG, "status code: %d", req->response->status_code);
                         }
-                    } else {
+                    }
+                    else {
                         req_list_set_from_string(req->response->header, line);
                         ESP_LOGD(REQ_TAG, "header line: %s", line);
                     }
@@ -616,47 +636,47 @@ static int req_process_download(request_t *req)
             }
         }
 
-        if(process_header == 0)
+        if (process_header == 0)
         {
-            if(req->buffer->at_eof) {
+            if (req->buffer->at_eof) {
                 fill_buffer(req);
             }
 
             req->buffer->bytes_read = req->buffer->bytes_write;
             content_len = req_list_get_key(req->response->header, "Content-Length");
-            if(content_len) {
+            if (content_len) {
                 req->response->len = atoi(content_len->value);
             }
-            if(req->response->len && req->download_callback && (req->buffer->bytes_write - header_off) != 0) {
-                if(req->download_callback(req, (void *)(req->buffer->data + header_off), req->buffer->bytes_write - header_off) < 0) break;
+            if (req->response->len && req->download_callback && (req->buffer->bytes_write - header_off) != 0) {
+                if (req->download_callback(req, (void *)(req->buffer->data + header_off), req->buffer->bytes_write - header_off) < 0) break;
 
                 req->buffer->bytes_total += req->buffer->bytes_write - header_off;
-                if(req->buffer->bytes_total == req->response->len) {
+                if (req->buffer->bytes_total == req->response->len) {
                     break;
                 }
             }
             header_off = 0;
-            if(req->response->len == 0) {
+            if (req->response->len == 0) {
                 break;
             }
 
         }
 
-    } while(req->buffer->at_eof == 0);
+    } while (req->buffer->at_eof == 0);
     return 0;
 }
 
 void req_websocket_task(void *pv)
 {
     request_t *req = pv;
-    while(req->valid_websocket) {
+    while (req->valid_websocket) {
         int len = req->_read(req, (char *)req->buffer->data, REQ_BUFFER_LEN);
-        if(len < 0) {
+        if (len < 0) {
             req->valid_websocket = 0;
             break;
         }
-        if(len > 0) {
-            if(req->websocket_callback) {
+        if (len > 0) {
+            if (req->websocket_callback) {
                 req->websocket_callback(req, WS_DATA, req->buffer->data, len);
             }
 
@@ -664,7 +684,7 @@ void req_websocket_task(void *pv)
 
     }
     req->_close(req);
-    if(req->websocket_callback) {
+    if (req->websocket_callback) {
         req->websocket_callback(req, WS_DISCONNECTED, NULL, 0);
     }
     vTaskDelete(NULL);
@@ -673,17 +693,17 @@ void req_websocket_task(void *pv)
 int req_perform(request_t *req)
 {
     do {
-        if(req->socket < 0) {
+        if (req->socket < 0) {
             REQ_CHECK(req->_connect(req) < 0, "Error connnect", break);
         }
         REQ_CHECK(req_process_upload(req) < 0, "Error send request", break);
         REQ_CHECK(req_process_download(req) < 0, "Error download", break);
-        if(req->valid_websocket) {
-            xTaskCreate(req_websocket_task, "req_websocket_task", 2*1024, req, 5, NULL);
+        if (req->valid_websocket) {
+            xTaskCreate(req_websocket_task, "req_websocket_task", 2 * 1024, req, 5, NULL);
         }
-        if((req->response->status_code == 301 || req->response->status_code == 302) && req_list_check_key(req->opt, "follow", "true")) {
+        if ((req->response->status_code == 301 || req->response->status_code == 302) && req_list_check_key(req->opt, "follow", "true")) {
             req_list_t *found = req_list_get_key(req->response->header, "Location");
-            if(found) {
+            if (found) {
                 req_list_set_key(req->header, "Referer", (const char*)found->value);
                 req_setopt_from_uri(req, (const char*)found->value);
                 ESP_LOGI(REQ_TAG, "Following: %s", (char*)found->value);
@@ -691,11 +711,12 @@ int req_perform(request_t *req)
                 continue;
             }
             break;
-        } else {
+        }
+        else {
             break;
         }
-    } while(1);
-    if(req->protocol == PROTOCOL_HTTP) {
+    } while (1);
+    if (req->protocol == PROTOCOL_HTTP) {
         req->_close(req);
     }
     return req->response->status_code;
@@ -710,7 +731,7 @@ int req_write(request_t *req, const char *buffer, int len)
 }
 void req_clean(request_t *req)
 {
-    if(req->valid_websocket) {
+    if (req->valid_websocket) {
         req->_close(req);
     }
     req_list_clear(req->opt);

--- a/esp_request.c
+++ b/esp_request.c
@@ -694,7 +694,7 @@ int req_perform(request_t *req)
 {
     do {
         if (req->socket < 0) {
-            REQ_CHECK(req->_connect(req) < 0, "Error connnect", break);
+            REQ_CHECK(req->_connect(req) < 0, "Error connnect", return -1);
         }
         REQ_CHECK(req_process_upload(req) < 0, "Error send request", break);
         REQ_CHECK(req_process_download(req) < 0, "Error download", break);


### PR DESCRIPTION
If there is a problem creating the req structure, there might be a memory leak. I am sure there is a nicer way to release partial memory allocations, but what I did was the minimum changes to the code.
There are some other minor changes that the editor did to spaces and such, it can be ignored. I also change the socket variable, because there is a function socket with the same name.

Alon.