### PR TITLE
Fixing memory leak in req_setopt

### DIFF
--- a/esp_request.c
+++ b/esp_request.c
@@ -348,9 +348,10 @@ void req_setopt(request_t *req, REQ_OPTS opt, void* data)
     int post_len;
     char len_str[10] = {0};
     req_list_t *tmp;
-    char *host_w_port = malloc(1024);
+    char *host_w_port = NULL;
     if(!req || !data)
         return;
+    host_w_port = malloc(1024);
     switch(opt) {
         case REQ_SET_METHOD:
             req_list_set_key(req->opt, "method", data);


### PR DESCRIPTION
A memory leak could happen if req was null or there was no data when call req_setopt, because it was returning after the malloc.

Moving the malloc after the check solves the issue.